### PR TITLE
Add CI via GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,38 @@
+name: Build
+
+on: [push, pull_request]
+
+jobs:
+  build-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - run: sudo apt-get update
+      - run: sudo apt-get install lazarus
+      - run: lazbuild --version
+      - uses: actions/checkout@v2
+      - run: make
+      - uses: actions/upload-artifact@v1
+        with:
+          name: linux
+          path: 'SmartSet FSEdge'
+
+  build-windows:
+    runs-on: windows-latest
+    steps:
+      -
+        name: install lazarus
+        uses: crazy-max/ghaction-chocolatey@v1
+        with:
+          args: install lazarus make
+      # https://github.community/t5/GitHub-Actions/Append-PATH-on-Windows/td-p/31120
+      - run: echo "##[add-path]C:\lazarus"
+      - run: lazbuild --version
+      - uses: actions/checkout@v2
+      -
+        name: remove checked-in artifact
+        run: Remove-Item -Recurse Components/richmemo/lib/x86_64-win64
+      - run: make
+      - uses: actions/upload-artifact@v1
+        with:
+          name: windows
+          path: 'SmartSet FSEdge'

--- a/Common/u_const.pas
+++ b/Common/u_const.pas
@@ -8,8 +8,7 @@ interface
 
 uses
   {$ifdef Win32}Windows, {$endif}
-  {$ifdef Darwin}LCLIntf, {$endif}
-  lcltype, Classes, SysUtils, FileUtil, Controls, Graphics, character, LazUTF8, U_Keys, Buttons,
+  LCLIntf, lcltype, Classes, SysUtils, FileUtil, Controls, Graphics, character, LazUTF8, U_Keys, Buttons,
   HSSpeedButton;
 
 type

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,46 @@
+ifeq ($(OS),Windows_NT)
+	platform = x86_64-win64
+	exe = ".exe"
+else
+    UNAME_S := $(shell uname -s)
+    ifeq ($(UNAME_S),Linux)
+		platform = x86_64-linux
+    endif
+    ifeq ($(UNAME_S),Darwin)
+		platform = x86_64-darwin
+    endif
+endif
+
+lazbuild = lazbuild
+
+creosource = Components/CreoSource/lib/$(platform)/creosource.compiled
+eccontrols = Components/ecc_0-9-6-10_16-06-15/EC_Controls/lib/$(platform)/eccontrols.compiled
+installpkg = Components/HSButton0.9/HSButton/lib/$(platform)/installpkg.compiled
+bgrabitmappack = Components/bgrabitmap-master/bgrabitmap/lib/$(platform)/3.0.4/BGRABitmapPack.compiled
+richmemopackage = Components/richmemo/lib/$(platform)/richmemopackage.compiled
+uecontrols = Components/ueControls_v6.0/lib/$(platform)/uEControls.compiled
+
+smartset = 'SmartSet FSEdge/SmartSet App-Freestyle (PC)'$(exe)
+
+all: $(smartset)
+
+$(smartset): $(creosource) $(eccontrols) $(installpkg) $(richmemopackage) $(uecontrols)
+	$(lazbuild) "SmartSet FSEdge/SmartSetFSEdge.lpi"
+
+$(uecontrols):
+	$(lazbuild) Components/ueControls_v6.0/uecontrols.lpk
+
+$(richmemopackage):
+	$(lazbuild) Components/richmemo/richmemopackage.lpk
+
+$(bgrabitmappack):
+	$(lazbuild) Components/bgrabitmap-master/bgrabitmap/bgrabitmappack.lpk
+
+$(creosource) : $(bgrabitmappack)
+	$(lazbuild) Components/CreoSource/creosource.lpk
+
+$(eccontrols):
+	$(lazbuild) Components/ecc_0-9-6-10_16-06-15/EC_Controls/eccontrols.lpk
+
+$(installpkg):
+	$(lazbuild) Components/HSButton0.9/HSButton/installpkg.lpk


### PR DESCRIPTION
This PR configures [GitHub Actions](https://help.github.com/en/actions) to build on Linux and Windows with every commit. Highlights:

- Here's an example of a successful run:

   https://github.com/jrr/Freestyle-Edge-Pro-SmartSet-App/actions/runs/55956548

- Each build saves its artifacts so you can easily download the latest executable.
- There's one small code change to `Common/u_const.pas` to fix the Linux build.
- I threw together a Makefile to handle component dependencies. I've never used Pascal or Lazarus before; I'd be glad to hear if there's a better way to build the whole project at once.

I have a Mac build running on a [branch](https://github.com/jrr/Freestyle-Edge-Pro-SmartSet-App/tree/feature/mac-ci), but it's failing with a couple [errors](https://github.com/jrr/Freestyle-Edge-Pro-SmartSet-App/runs/509173548?check_suite_focus=true). Is the latest Mac-specific work pushed up to this repo?